### PR TITLE
Use nokogiri

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .bundle
 Gemfile.lock
 pkg/*
+.DS_Store

--- a/lib/x12.rb
+++ b/lib/x12.rb
@@ -24,6 +24,8 @@
 # $Id: X12.rb 91 2009-05-13 22:11:10Z ikk $
 #
 # Package implementing direct manipulation of X12 structures using Ruby syntax.
+require 'nokogiri'
+
 require "x12/version"
 require 'x12/base'
 require 'x12/empty'

--- a/lib/x12/parser.rb
+++ b/lib/x12/parser.rb
@@ -22,10 +22,6 @@
 #++
 #
 
-require "rexml/document"
-
-require 'pp'
-
 module X12
 
   # $Id: Parser.rb 89 2009-05-13 19:36:20Z ikk $
@@ -73,7 +69,6 @@ module X12
 
       # Populate fields in all segments found in all the loops
       @x12_definition[X12::Loop].each_pair{|k, v|
-        #puts "Populating definitions for loop #{k}"
         process_loop(v)
       } if @x12_definition[X12::Loop]
 
@@ -88,13 +83,11 @@ module X12
         }
       end
 
-      #puts PP.pp(self, '')
     end # initialize
 
     # Parse a loop of a given name out of a string. Throws an exception if the loop name is not defined.
     def parse(loop_name, str)
       loop = @x12_definition[X12::Loop][loop_name]
-      #puts "Loops to parse #{@x12_definition[X12::Loop].keys}"
       throw Exception.new("Cannot find a definition for loop #{loop_name}") unless loop
       loop = loop.dup
       loop.parse(str)
@@ -128,7 +121,6 @@ module X12
 
     # Instantiate segment's fields as previously defined
     def process_segment(segment)
-      #puts "Trying to process segment #{segment.inspect}"
       unless @x12_definition[X12::Segment] && @x12_definition[X12::Segment][segment.name]
         # Try to find it in a separate file if missing from the @x12_definition structure
         initialize(File.join(@dir_name, segment.name+'.xml'))

--- a/lib/x12/xmldefinitions.rb
+++ b/lib/x12/xmldefinitions.rb
@@ -37,7 +37,6 @@ module X12
       doc = REXML::Document.new(str)
       definitions = doc.root.name =~ /^Definition$/i ? doc.root.elements.to_a : [doc.root]
       definitions.each { |element|
-        #puts element.name
         syntax_element = case element.name
                          when /table/i
                            parse_table(element)

--- a/spec/classes/xml_definitions_spec.rb
+++ b/spec/classes/xml_definitions_spec.rb
@@ -1,29 +1,97 @@
 require 'spec_helper'
 describe X12::XMLDefinitions do
   describe "#initialize" do
-    context "a simple document with an embedded loop" do
+    let(:something) { double(name: :something) }
 
-      it "parses the next tag" do
-        obj = X12::XMLDefinitions.new('<Definition><Loop name="test" comment="test"></Loop></Definition>')
+    context "where the root is a definition" do
+      it "parses the loop element" do
+        described_class.any_instance.should_receive(:parse_loop).and_return(something)
+        described_class.new('<Definition><Loop name="test" comment="test"></Loop></Definition>')
+      end
+    end
 
-        obj.keys.size.should == 1
+    context "where the root is not a definition" do
+
+      it "parses the loop element" do
+        described_class.any_instance.should_receive(:parse_loop).and_return(something)
+        described_class.new('<Loop name="test" comment="test"></Loop>')
+      end
+    end
+
+    context "a loop" do
+
+      subject { described_class.new('<Definition><Loop name="test" comment="test"></Loop></Definition>') }
+
+      context "containing another loop" do
+        subject { described_class.new('<Loop name="outer"><Loop name="inner" comment="test"></Loop></Loop>') }
+
+        it "parses the outer loop" do
+          expect(subject[X12::Loop].keys).to eq [ "outer" ]
+        end
+
+        it "parses the inner loop" do
+          inner = subject[X12::Loop]["outer"].nodes
+          expect(inner.first).to be_an_instance_of X12::Loop
+        end
+      end
+
+      context "containing a segment" do
+        subject { described_class.new('<Loop name="outer"><Segment name="inner" comment="test" /></Loop>') }
+
+        it "parses the outer loop" do
+          expect(subject[X12::Loop].keys).to eq [ "outer" ]
+        end
+
+        it "parses the inner loop" do
+          inner = subject[X12::Loop]["outer"].nodes
+          expect(inner.first.class).to eq X12::Segment
+        end
       end
 
     end
-  end
 
-  describe "#loop" do
-    let(:loop) { REXML::Document.new('<loop name="test" comment="test"></loop>') }
+    context "a table" do
+      subject { described_class.new('<Table name="test"><Entry name="A" value="something"/><Entry name="B" value="another" /></Table>') }
 
-    subject { X12::XMLDefinitions.new("<Definition />") }
+      it "parses the table" do
+        expect(subject[X12::Table].keys).to eq [ "test" ]
+      end
 
-    it "parses the parameters out of a loop" do
-      #parse = subject.loop(loop)
+      it "parses the entries" do
+        table = subject[X12::Table]["test"]
 
-      #parse.class.should == Loop
+        expect(table).to eq({"A" => "something", "B" => "another"})
+      end
+    end
 
+    context "a segment" do
+      subject { described_class.new('<Segment name="ST" required="y" max="1"><Field name="field1" const="270" comment="field"/></Segment>') }
+
+      it "parses the segment" do
+        expect(subject[X12::Segment].keys).to eq [ "ST" ]
+      end
+
+      it "parses the fields" do
+        segment = subject[X12::Segment]["ST"]
+
+        expect(segment.nodes.map(&:class)).to eq [ X12::Field ]
+      end
+    end
+
+    context "a composite" do
+      subject { described_class.new('<Composite name="C043" comment="foo"><Field name="field1" min="1" max="30" comment="fieldcomment"/></Composite>') }
+
+      it "parses the composite" do
+        expect(subject[X12::Composite].keys).to eq [ "C043" ]
+      end
+
+      it "parses the fields" do
+
+        composite = subject[X12::Composite]["C043"]
+
+        expect(composite.nodes.map(&:class)).to eq [ X12::Field ]
+      end
     end
 
   end
-
 end

--- a/x12.gemspec
+++ b/x12.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec')
   s.add_development_dependency('awesome_print')
   s.add_development_dependency('rake')
-  s.add_development_dependency('byebug')
+  s.add_development_dependency('byebug') if RUBY_VERSION =~ /^2/
 end

--- a/x12.gemspec
+++ b/x12.gemspec
@@ -18,8 +18,11 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.add_dependency 'nokogiri'
+
   s.add_development_dependency('rdoc')
   s.add_development_dependency('rspec')
   s.add_development_dependency('awesome_print')
   s.add_development_dependency('rake')
+  s.add_development_dependency('byebug')
 end


### PR DESCRIPTION
Fixes #7 

Switched XML parsing to use nokogiri instead of REXML.

Test suite runs in 1s using nokogiri vs 19s using REXML.

```
x12(master %) $ time RUBYLIB="./lib" ruby ./benchmark.rb

real    0m1.478s
user    0m1.421s
sys 0m0.056s

x12(master %) $ git checkout use_nokogiri
Switched to branch 'use_nokogiri'
x12(use_nokogiri %) $ time RUBYLIB="./lib" ruby ./benchmark.rb

real    0m0.253s
user    0m0.197s
sys 0m0.051s
```

```
x12(use_nokogiri) $ time rspec
...............................................................................

Finished in 0.33452 seconds
79 examples, 0 failures

real    0m1.026s
user    0m0.881s
sys 0m0.134s
x12(use_nokogiri) $ git checkout master
Switched to branch 'master'
x12(master %) $ time rspec
.....................................................................

Finished in 18.49 seconds
69 examples, 0 failures

real    0m19.175s
user    0m18.753s
sys 0m0.411s
```
